### PR TITLE
增添支持对'基础性作业'的下载

### DIFF
--- a/src/tchMaterial-parser.pyw
+++ b/src/tchMaterial-parser.pyw
@@ -58,7 +58,10 @@ def parse(url): # 解析 URL
         }
         """
         # 其中 $.ti_items 的每一项对应一个电子课本
-        response = requests.get(f"https://s-file-1.ykt.cbern.com.cn/zxx/ndrv2/resources/tch_material/details/{contentId}.json", proxies={ "http": None, "https": None })
+        if "syncClassroom/basicWork/detail" in url: # 对于“基础性作业”的解析
+            response = requests.get(f"https://s-file-1.ykt.cbern.com.cn/zxx/ndrs/special_edu/resources/details/{contentId}.json", proxies={ "http": None, "https": None })
+        else: # 对于课本的解析
+            response = requests.get(f"https://s-file-1.ykt.cbern.com.cn/zxx/ndrv2/resources/tch_material/details/{contentId}.json", proxies={ "http": None, "https": None })
         data = json.loads(response.text)
         for item in list(data["ti_items"]):
             if item["lc_ti_format"] == "pdf": # 找到存有 PDF 链接列表的项


### PR DESCRIPTION
close #9 
如标题所言，

其实只是在`parse(url)`函数中加了三行代码，因为'基础性作业'和课本的下载逻辑一样