### PR TITLE
结束自身进程时,改用 sys.exit(0)

### DIFF
--- a/src/tchMaterial-parser.pyw
+++ b/src/tchMaterial-parser.pyw
@@ -8,6 +8,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 import os, platform
+import sys
 from functools import partial
 import base64, tempfile
 import threading, requests, psutil
@@ -562,10 +563,7 @@ def on_closing() -> None: # 处理窗口关闭事件
             pass
 
     # 结束自身进程
-    try:
-        current_process.terminate()
-    except: # 进程可能已经结束
-        pass
+    sys.exit(0)
 
 root.protocol("WM_DELETE_WINDOW", on_closing) # 注册窗口关闭事件的处理函数
 


### PR DESCRIPTION
​使用 `terminate()` 终止自身进程可能引发异常​​，该 PR 将其改为 `sys.exit(0)`  
  
  
运行原程序时正常退出时：
```
$ python src/tchMaterial-parser.pyw
fish: Job 1, 'python src/tchMaterial-parser.p…' terminated by signal SIGTERM (Polite quit request)
```
原程序返回 `143`