### PR TITLE
改进文本显示

### DIFF
--- a/src/tchMaterial-parser.pyw
+++ b/src/tchMaterial-parser.pyw
@@ -709,7 +709,7 @@ for i in range(8):
     drop.config(state="active") # 配置下拉菜单为始终活跃状态，保证下拉菜单一直有形状
     drop.bind("<Leave>", lambda e: "break") # 绑定鼠标移出事件，当鼠标移出下拉菜单时，执行 lambda 函数，“break”表示中止事件传递
     drop.grid(row=i // 4, column=i % 4, padx=int(15 * scale), pady=int(15 * scale)) # 设置位置，2 行 4 列（跟随缩放）
-    variables[i].set("---")
+    variables[i].set("分类")
     drops.append(drop)
 
 # 按钮：设置 Token


### PR DESCRIPTION
如图
<img width="1219" height="680" alt="图片" src="https://github.com/user-attachments/assets/5f6dd08b-d070-4e50-bea0-719d9542ff9a" />
感觉更容易让用户知道这下面的是什么功能并让用户更可能使用它
PS.说实话，我看见这个按钮<img width="62" height="25" alt="图片" src="https://github.com/user-attachments/assets/8fe3b631-cc40-41a9-b12e-0cb4c92898b8" />的时候，第一反应是“WC，我的linux有bug！显示不正常！”
