### PR TITLE
feat: 在下载之前检测 Access Token 是否包含非 ASCII 字符

### DIFF
--- a/src/tchmaterial_parser/ui/download_panel.py
+++ b/src/tchmaterial_parser/ui/download_panel.py
@@ -60,6 +60,11 @@ def download() -> None: # 下载资源文件
     resource_urls: set[str] = set()
     failed_urls: set[str] = set()
 
+    if not config.access_token.isascii(): # 判断 Access Token 中是否包含非 ASCII 字符
+        messagebox.showwarning("警告", "Access Token 不正确（包含非 ASCII 字符），请点击“设置 Token”按钮重新填写。")
+        download_btn.config(state="normal") # 恢复下载按钮为启用状态
+        return
+
     for url in urls:
         resources_info = parse(url, bookmark_var.get())
         if not resources_info:


### PR DESCRIPTION
用户在 Access Token 误输入非 ASCII 字符时，只会显示下方贴出的异常堆栈.

这个 PR 增加了在下载前的检测并提示用户操作.

（把检测放在 `download()` 而不是 `set_token()` 是在防止用户错误地直接修改注册表/文件）
```
Traceback (most recent call last):
  File "/home/iamzhz/code/tchMaterial-parser/src/tchmaterial_parser/api.py", line 178, in get_resource_info
    tree_resp = session.get(f"https://s-file-1.ykt.cbern.com.cn/zxx/ndrv2/national_lesson/trees/{ebook_id}.json", headers=headers)
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 671, in get
    return self.request("GET", url, params=params, **kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 651, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 784, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.14/site-packages/requests/adapters.py", line 696, in send
    resp = conn.urlopen(
        method=request.method,
    ...<9 lines>...
        chunked=chunked,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 788, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 493, in _make_request
    conn.request(
    ~~~~~~~~~~~~^
        method,
        ^^^^^^^
    ...<6 lines>...
        enforce_content_length=enforce_content_length,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 499, in request
    self.putheader(header, value)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 413, in putheader
    super().putheader(header, *values)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/http/client.py", line 1359, in putheader
    values[i] = one_value.encode('latin-1')
                ~~~~~~~~~~~~~~~~^^^^^^^^^^^
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 7-8: ordinal not in range(256)
Traceback (most recent call last):
  File "/home/iamzhz/code/tchMaterial-parser/src/tchmaterial_parser/ui/download_panel.py", line 114, in download_file
    response = session.get(url, headers=headers, stream=True)
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 671, in get
    return self.request("GET", url, params=params, **kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 651, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 784, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.14/site-packages/requests/adapters.py", line 696, in send
    resp = conn.urlopen(
        method=request.method,
    ...<9 lines>...
        chunked=chunked,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 788, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 493, in _make_request
    conn.request(
    ~~~~~~~~~~~~^
        method,
        ^^^^^^^
    ...<6 lines>...
        enforce_content_length=enforce_content_length,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 499, in request
    self.putheader(header, value)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 413, in putheader
    super().putheader(header, *values)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/http/client.py", line 1359, in putheader
    values[i] = one_value.encode('latin-1')
                ~~~~~~~~~~~~~~~~^^^^^^^^^^^
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 7-8: ordinal not in range(256)

```