### PR TITLE
fix: 未检验 config.access_token 是否为 None

### DIFF
--- a/src/tchmaterial_parser/ui/download_panel.py
+++ b/src/tchmaterial_parser/ui/download_panel.py
@@ -60,7 +60,7 @@ def download() -> None: # 下载资源文件
     resource_urls: set[str] = set()
     failed_urls: set[str] = set()
 
-    if not config.access_token.isascii(): # 判断 Access Token 中是否包含非 ASCII 字符
+    if config.access_token and not config.access_token.isascii(): # 判断 Access Token 中是否包含非 ASCII 字符
         messagebox.showwarning("警告", "Access Token 不正确（包含非 ASCII 字符），请点击“设置 Token”按钮重新填写。")
         download_btn.config(state="normal") # 恢复下载按钮为启用状态
         return


### PR DESCRIPTION
非常抱歉！
我在 #75 中疏忽未设置 Access Token 的情况了，导致这些用户使用时会出错.
```
File "/home/iamzhz/code/tchMaterial-parser/src/tchmaterial_parser/ui/download_panel.py", line 63, in download
  if not config.access_token.isascii(): # 判断 Access Token 中是否包含非 ASCII 字符
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isascii'
```
（这算因小失大吗...）
于是就有了这个 PR  (╯︵╰,)